### PR TITLE
Add .envrc to ease script usage

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+PATH_add ./scripts
+
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/output
+
+.envrc.local


### PR DESCRIPTION
Adds ./scripts to path for direnv users and allows a .envrc.local to be added by users that will not be tracked by git