### PR TITLE
Only set basic s3 credentials in sdk if configuration is set

### DIFF
--- a/charts/beskar-yum/templates/_helpers.tpl
+++ b/charts/beskar-yum/templates/_helpers.tpl
@@ -88,6 +88,7 @@ Create the name of the service account to use
       name: {{ template "beskar-yum.fullname" . }}-secret
       key: azureAccountKey
 {{- else if eq .Values.configData.storage.driver "s3" }}
+  {{- if and .Values.secrets.s3.secretKey .Values.secrets.s3.accessKey }}
 - name: BESKARYUM_STORAGE_S3_ACCESSKEYID
   valueFrom:
     secretKeyRef:
@@ -98,6 +99,7 @@ Create the name of the service account to use
     secretKeyRef:
       name: {{ template "beskar-yum.fullname" . }}-secret
       key: s3SecretKey
+  {{- end }}
 {{- else if eq .Values.configData.storage.driver "gcs" }}
 - name: BESKARYUM_STORAGE_GCS_KEYFILE
   value: /etc/gcs-keyfile

--- a/internal/pkg/yumplugin/pkg/storage/s3.go
+++ b/internal/pkg/yumplugin/pkg/storage/s3.go
@@ -15,15 +15,26 @@ import (
 func initS3(ctx context.Context, storageConfig config.BeskarYumS3Storage, prefix string) (*blob.Bucket, error) {
 	bucketName := storageConfig.Bucket
 
+	opts := []s3.AuthMethodOption{
+		s3.WithDisableSSL(storageConfig.DisableSSL),
+	}
+
+	if storageConfig.AccessKeyID != "" || storageConfig.SecretAccessKey != "" || storageConfig.SessionToken != "" {
+		opts = append(opts,
+			s3.WithCredentials(
+				storageConfig.AccessKeyID,
+				storageConfig.SecretAccessKey,
+				storageConfig.SessionToken,
+			))
+	}
+
+	if storageConfig.Region != "" {
+		opts = append(opts, s3.WithRegion(storageConfig.Region))
+	}
+
 	authMethod, err := s3.NewAuthMethod(
 		storageConfig.Endpoint,
-		s3.WithCredentials(
-			storageConfig.AccessKeyID,
-			storageConfig.SecretAccessKey,
-			storageConfig.SessionToken,
-		),
-		s3.WithRegion(storageConfig.Region),
-		s3.WithDisableSSL(storageConfig.DisableSSL),
+		opts...,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This allows the aws sdk to leverage the credential provider chain by default.

https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html