### PR TITLE
Implement DeleteRepository on YUM and Static plugins

### DIFF
--- a/internal/plugins/static/api.go
+++ b/internal/plugins/static/api.go
@@ -22,7 +22,7 @@ func (p *Plugin) DeleteRepository(ctx context.Context, repository string) (err e
 	if err := checkRepository(repository); err != nil {
 		return err
 	}
-	return p.repositoryManager.Get(ctx, repository).DeleteRepository(ctx)
+	return p.repositoryManager.Get(ctx, repository).DeleteRepository(ctx, repository)
 }
 
 func (p *Plugin) ListRepositoryLogs(ctx context.Context, repository string, page *apiv1.Page) (logs []apiv1.RepositoryLog, err error) {

--- a/internal/plugins/static/api.go
+++ b/internal/plugins/static/api.go
@@ -18,11 +18,11 @@ func checkRepository(repository string) error {
 	return nil
 }
 
-func (p *Plugin) DeleteRepository(ctx context.Context, repository string) (err error) {
+func (p *Plugin) DeleteRepository(ctx context.Context, repository string, deletePackages bool) (err error) {
 	if err := checkRepository(repository); err != nil {
 		return err
 	}
-	return p.repositoryManager.Get(ctx, repository).DeleteRepository(ctx, repository)
+	return p.repositoryManager.Get(ctx, repository).DeleteRepository(ctx, repository, deletePackages)
 }
 
 func (p *Plugin) ListRepositoryLogs(ctx context.Context, repository string, page *apiv1.Page) (logs []apiv1.RepositoryLog, err error) {

--- a/internal/plugins/static/pkg/staticrepository/api.go
+++ b/internal/plugins/static/pkg/staticrepository/api.go
@@ -34,7 +34,11 @@ func (h *Handler) DeleteRepository(ctx context.Context, repository string, delet
 		return werror.Wrap(gcode.ErrInternal, err)
 	}
 
-	if len(repositoryFiles) > 0 && deletePackages {
+	if len(repositoryFiles) > 0 {
+		if !deletePackages {
+			return werror.Wrap(gcode.ErrInternal, fmt.Errorf("err deleting static repository: files must be deleted from repository"))
+		}
+
 		for _, file := range repositoryFiles {
 			err = h.RemoveRepositoryFile(ctx, file.Tag)
 			if err != nil {

--- a/internal/plugins/yum/api.go
+++ b/internal/plugins/yum/api.go
@@ -29,7 +29,7 @@ func (p *Plugin) DeleteRepository(ctx context.Context, repository string) (err e
 	if err := checkRepository(repository); err != nil {
 		return err
 	}
-	return p.repositoryManager.Get(ctx, repository).DeleteRepository(ctx)
+	return p.repositoryManager.Get(ctx, repository).DeleteRepository(ctx, repository)
 }
 
 func (p *Plugin) UpdateRepository(ctx context.Context, repository string, properties *apiv1.RepositoryProperties) (err error) {

--- a/internal/plugins/yum/api.go
+++ b/internal/plugins/yum/api.go
@@ -25,11 +25,11 @@ func (p *Plugin) CreateRepository(ctx context.Context, repository string, proper
 	return p.repositoryManager.Get(ctx, repository).CreateRepository(ctx, properties)
 }
 
-func (p *Plugin) DeleteRepository(ctx context.Context, repository string) (err error) {
+func (p *Plugin) DeleteRepository(ctx context.Context, repository string, deletePackages bool) (err error) {
 	if err := checkRepository(repository); err != nil {
 		return err
 	}
-	return p.repositoryManager.Get(ctx, repository).DeleteRepository(ctx, repository)
+	return p.repositoryManager.Get(ctx, repository).DeleteRepository(ctx, repository, deletePackages)
 }
 
 func (p *Plugin) UpdateRepository(ctx context.Context, repository string, properties *apiv1.RepositoryProperties) (err error) {

--- a/internal/plugins/yum/pkg/yumdb/status.go
+++ b/internal/plugins/yum/pkg/yumdb/status.go
@@ -248,6 +248,35 @@ func (db *StatusDB) UpdateProperties(ctx context.Context, properties *Properties
 	return nil
 }
 
+func (db *StatusDB) DeleteProperties(ctx context.Context) error {
+	db.Reference.Add(1)
+	defer db.Reference.Add(-1)
+
+	if err := db.Open(ctx); err != nil {
+		return err
+	}
+
+	db.Lock()
+	result, err := db.ExecContext(
+		ctx,
+		"DELETE FROM properties WHERE id = 1",
+	)
+	db.Unlock()
+
+	if err != nil {
+		return err
+	}
+
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return err
+	} else if deleted != 1 {
+		return fmt.Errorf("properties not deleted in status database")
+	}
+
+	return nil
+}
+
 func (db *StatusDB) GetReposync(ctx context.Context) (*Reposync, error) {
 	db.Reference.Add(1)
 	defer db.Reference.Add(-1)
@@ -304,6 +333,35 @@ func (db *StatusDB) UpdateReposync(ctx context.Context, reposync *Reposync) erro
 		return err
 	} else if inserted != 1 {
 		return fmt.Errorf("reposync not updated in status database")
+	}
+
+	return nil
+}
+
+func (db *StatusDB) DeleteReposync(ctx context.Context) error {
+	db.Reference.Add(1)
+	defer db.Reference.Add(-1)
+
+	if err := db.Open(ctx); err != nil {
+		return err
+	}
+
+	db.Lock()
+	result, err := db.ExecContext(
+		ctx,
+		"DELETE FROM reposync WHERE id = 1",
+	)
+	db.Unlock()
+
+	if err != nil {
+		return err
+	}
+
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return err
+	} else if deleted != 1 {
+		return fmt.Errorf("reposync not deleted in status database")
 	}
 
 	return nil

--- a/internal/plugins/yum/pkg/yumrepository/api.go
+++ b/internal/plugins/yum/pkg/yumrepository/api.go
@@ -94,7 +94,11 @@ func (h *Handler) DeleteRepository(ctx context.Context, repository string, delet
 		return werror.Wrap(gcode.ErrInternal, err)
 	}
 
-	if len(repositoryPackages) > 0 && deletePackages {
+	if len(repositoryPackages) > 0 {
+		if !deletePackages {
+			return werror.Wrap(gcode.ErrInternal, fmt.Errorf("err deleting yum repository: pkgs must be deleted from repository"))
+		}
+
 		for _, pkg := range repositoryPackages {
 			err = h.RemoveRepositoryPackageByTag(ctx, pkg.Tag)
 			if err != nil {

--- a/pkg/plugins/static/api/v1/api.go
+++ b/pkg/plugins/static/api/v1/api.go
@@ -52,7 +52,7 @@ type Static interface {
 	// Delete a static repository.
 	//kun:op DELETE /repository
 	//kun:success statusCode=200
-	DeleteRepository(ctx context.Context, repository string) (err error)
+	DeleteRepository(ctx context.Context, repository string, deletePackages bool) (err error)
 
 	// List static repository logs.
 	//kun:op GET /repository/logs

--- a/pkg/plugins/static/api/v1/endpoint.go
+++ b/pkg/plugins/static/api/v1/endpoint.go
@@ -13,6 +13,7 @@ import (
 
 type DeleteRepositoryRequest struct {
 	Repository string `json:"repository"`
+	DeletePackages bool `json:"deletePackages"`
 }
 
 // ValidateDeleteRepositoryRequest creates a validator for DeleteRepositoryRequest.
@@ -39,6 +40,7 @@ func MakeEndpointOfDeleteRepository(s Static) endpoint.Endpoint {
 		err := s.DeleteRepository(
 			ctx,
 			req.Repository,
+			req.DeletePackages,
 		)
 		return &DeleteRepositoryResponse{
 			Err: err,

--- a/pkg/plugins/static/api/v1/http_client.go
+++ b/pkg/plugins/static/api/v1/http_client.go
@@ -34,7 +34,7 @@ func NewHTTPClient(codecs httpcodec.Codecs, httpClient *http.Client, baseURL str
 	}, nil
 }
 
-func (c *HTTPClient) DeleteRepository(ctx context.Context, repository string) (err error) {
+func (c *HTTPClient) DeleteRepository(ctx context.Context, repository string, deletePackages bool) (err error) {
 	codec := c.codecs.EncodeDecoder("DeleteRepository")
 
 	path := "/repository"
@@ -46,8 +46,10 @@ func (c *HTTPClient) DeleteRepository(ctx context.Context, repository string) (e
 
 	reqBody := struct {
 		Repository string `json:"repository"`
+		DeletePackages bool `json:"deletePackages"`
 	}{
 		Repository: repository,
+		DeletePackages: deletePackages,
 	}
 	reqBodyReader, headers, err := codec.EncodeRequestBody(&reqBody)
 	if err != nil {

--- a/pkg/plugins/static/api/v1/oas2.go
+++ b/pkg/plugins/static/api/v1/oas2.go
@@ -120,6 +120,7 @@ func getDefinitions(schema oas2.Schema) map[string]oas2.Definition {
 
 	oas2.AddDefinition(defs, "DeleteRepositoryRequestBody", reflect.ValueOf(&struct {
 		Repository string `json:"repository"`
+    DeletePackages bool `json:"deletePackages"`
 	}{}))
 	oas2.AddResponseDefinitions(defs, schema, "DeleteRepository", 200, (&DeleteRepositoryResponse{}).Body())
 

--- a/pkg/plugins/yum/api/v1/api.go
+++ b/pkg/plugins/yum/api/v1/api.go
@@ -89,7 +89,7 @@ type YUM interface { //nolint:interfacebloat
 	// Delete a YUM repository.
 	//kun:op DELETE /repository
 	//kun:success statusCode=200
-	DeleteRepository(ctx context.Context, repository string) (err error)
+	DeleteRepository(ctx context.Context, repository string, deletePackages bool) (err error)
 
 	// Update YUM repository properties.
 	//kun:op PUT /repository

--- a/pkg/plugins/yum/api/v1/endpoint.go
+++ b/pkg/plugins/yum/api/v1/endpoint.go
@@ -50,6 +50,7 @@ func MakeEndpointOfCreateRepository(s YUM) endpoint.Endpoint {
 
 type DeleteRepositoryRequest struct {
 	Repository string `json:"repository"`
+	DeletePackages bool `json:"deletePackages"`
 }
 
 // ValidateDeleteRepositoryRequest creates a validator for DeleteRepositoryRequest.
@@ -76,6 +77,7 @@ func MakeEndpointOfDeleteRepository(s YUM) endpoint.Endpoint {
 		err := s.DeleteRepository(
 			ctx,
 			req.Repository,
+			req.DeletePackages,
 		)
 		return &DeleteRepositoryResponse{
 			Err: err,

--- a/pkg/plugins/yum/api/v1/http_client.go
+++ b/pkg/plugins/yum/api/v1/http_client.go
@@ -83,7 +83,7 @@ func (c *HTTPClient) CreateRepository(ctx context.Context, repository string, pr
 	return nil
 }
 
-func (c *HTTPClient) DeleteRepository(ctx context.Context, repository string) (err error) {
+func (c *HTTPClient) DeleteRepository(ctx context.Context, repository string, deletePackages bool) (err error) {
 	codec := c.codecs.EncodeDecoder("DeleteRepository")
 
 	path := "/repository"
@@ -95,8 +95,10 @@ func (c *HTTPClient) DeleteRepository(ctx context.Context, repository string) (e
 
 	reqBody := struct {
 		Repository string `json:"repository"`
+		DeletePackages bool `json:"deletePackages"`
 	}{
 		Repository: repository,
+		DeletePackages: deletePackages,
 	}
 	reqBodyReader, headers, err := codec.EncodeRequestBody(&reqBody)
 	if err != nil {

--- a/pkg/plugins/yum/api/v1/oas2.go
+++ b/pkg/plugins/yum/api/v1/oas2.go
@@ -199,6 +199,7 @@ func getDefinitions(schema oas2.Schema) map[string]oas2.Definition {
 
 	oas2.AddDefinition(defs, "DeleteRepositoryRequestBody", reflect.ValueOf(&struct {
 		Repository string `json:"repository"`
+    DeletePackages bool `json:"deletePackages"`
 	}{}))
 	oas2.AddResponseDefinitions(defs, schema, "DeleteRepository", 200, (&DeleteRepositoryResponse{}).Body())
 


### PR DESCRIPTION
This change implements DeleteRepository on the yum and static plugin APIs. 

As the name implies, these APIs remove the references from of the given repository in beskar's DBs. I've also included an additional parameter deletePackages. This parameter gives the client the option to delete the packages with the repository. By default, the repository will only be deleted if it is not associated with any packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced repository deletion process with an option to remove associated packages.

- **Documentation**
  - Updated API documentation to reflect new repository deletion capabilities.

- **Refactor**
  - Improved internal handling of repository deletion to ensure a more robust and flexible operation.

Please note that these changes may affect how you interact with the repository deletion feature. Users can now choose whether to delete just the repository or include the deletion of related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->