### PR TITLE
Beskar-yum: Add a sync handler that accepts a URL with credentials

### DIFF
--- a/build/mage/common.go
+++ b/build/mage/common.go
@@ -99,8 +99,8 @@ func getChartsSource(client *dagger.Client) *dagger.Directory {
 func goCache(client *dagger.Client) func(dc *dagger.Container) *dagger.Container {
 	return func(dc *dagger.Container) *dagger.Container {
 		return dc.
-			WithMountedCache("/go", client.CacheVolume("go-mod-cache"), dagger.ContainerWithMountedCacheOpts{Sharing: dagger.Shared}).
-			WithMountedCache("/root/.cache", client.CacheVolume("go-build-cache"), dagger.ContainerWithMountedCacheOpts{Sharing: dagger.Shared})
+			WithMountedCache("/go", client.CacheVolume("go-mod-cache"), dagger.ContainerWithMountedCacheOpts{Sharing: dagger.Locked}).
+			WithMountedCache("/root/.cache", client.CacheVolume("go-build-cache"), dagger.ContainerWithMountedCacheOpts{Sharing: dagger.Locked})
 	}
 }
 

--- a/integration/beskar_yum_test.go
+++ b/integration/beskar_yum_test.go
@@ -247,6 +247,22 @@ var _ = Describe("Beskar YUM Plugin", func() {
 			Expect(status.EndTime).ToNot(BeEmpty())
 		})
 
+		It("Sync Repository With URL", func() {
+			err := beskarYUMClient().SyncRepositoryWithURL(context.Background(), repositoryAPIName, repo.AuthMirrorURL, true)
+			Expect(err).To(BeNil())
+		})
+
+		It("Sync Status", func() {
+			status, err := beskarYUMClient().GetRepositorySyncStatus(context.Background(), repositoryAPIName)
+			Expect(err).To(BeNil())
+			Expect(status.Syncing).To(BeFalse())
+			Expect(status.SyncError).To(BeEmpty())
+			Expect(status.SyncedPackages).To(Equal(len(repo.Files)))
+			Expect(status.TotalPackages).To(Equal(len(repo.Files)))
+			Expect(status.StartTime).ToNot(BeEmpty())
+			Expect(status.EndTime).ToNot(BeEmpty())
+		})
+
 		It("Access Repository Artifacts", func() {
 			for filename := range repo.Files {
 				info, ok := repo.Files[filename]

--- a/integration/pkg/repoconfig/parse.go
+++ b/integration/pkg/repoconfig/parse.go
@@ -8,11 +8,12 @@ type File struct {
 }
 
 type Repository struct {
-	URL       string          `yaml:"url"`
-	LocalPath string          `yaml:"local-path"`
-	MirrorURL string          `yaml:"mirror-url"`
-	GPGKey    string          `yaml:"gpgkey"`
-	Files     map[string]File `yaml:"files"`
+	URL           string          `yaml:"url"`
+	LocalPath     string          `yaml:"local-path"`
+	MirrorURL     string          `yaml:"mirror-url"`
+	AuthMirrorURL string          `yaml:"auth-mirror-url"`
+	GPGKey        string          `yaml:"gpgkey"`
+	Files         map[string]File `yaml:"files"`
 }
 
 type Repositories map[string]Repository

--- a/integration/testdata/repoconfig.yaml
+++ b/integration/testdata/repoconfig.yaml
@@ -3,6 +3,7 @@ vault-rocky-8.3-ha-debug:
   local-path: testdata/vault-rocky-8.3-ha-debug
   url: http://127.0.0.1:8080/vault-rocky-8.3-ha-debug/Packages
   mirror-url: http://127.0.0.1:8080/vault-rocky-8.3-ha-debug
+  auth-mirror-url: http://test:test-password@127.0.0.1:8080/auth/vault-rocky-8.3-ha-debug
   gpgkey: |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
 

--- a/internal/plugins/yum/api.go
+++ b/internal/plugins/yum/api.go
@@ -53,6 +53,13 @@ func (p *Plugin) SyncRepository(ctx context.Context, repository string, wait boo
 	return p.repositoryManager.Get(ctx, repository).SyncRepository(ctx, wait)
 }
 
+func (p *Plugin) SyncRepositoryWithURL(ctx context.Context, repository, url string, wait bool) (err error) {
+	if err := checkRepository(repository); err != nil {
+		return err
+	}
+	return p.repositoryManager.Get(ctx, repository).SyncRepositoryWithURL(ctx, url, wait)
+}
+
 func (p *Plugin) GetRepositorySyncStatus(ctx context.Context, repository string) (syncStatus *apiv1.SyncStatus, err error) {
 	if err := checkRepository(repository); err != nil {
 		return nil, err

--- a/pkg/plugins/yum/api/v1/api.go
+++ b/pkg/plugins/yum/api/v1/api.go
@@ -115,6 +115,11 @@ type YUM interface { //nolint:interfacebloat
 	//kun:success statusCode=200
 	SyncRepository(ctx context.Context, repository string, wait bool) (err error)
 
+	// Sync YUM repository with an upstream repository using a specified URL.
+	//kun:op GET /repository/sync:url
+	//kun:success statusCode=200
+	SyncRepositoryWithURL(ctx context.Context, repository, mirrorURL string, wait bool) (err error)
+
 	// Get YUM repository sync status.
 	//kun:op GET /repository/sync:status
 	//kun:success statusCode=200

--- a/pkg/plugins/yum/api/v1/endpoint.go
+++ b/pkg/plugins/yum/api/v1/endpoint.go
@@ -426,6 +426,45 @@ func MakeEndpointOfSyncRepository(s YUM) endpoint.Endpoint {
 	}
 }
 
+type SyncRepositoryWithURLRequest struct {
+	Repository string `json:"repository"`
+	MirrorURL  string `json:"mirror_url"`
+	Wait       bool   `json:"wait"`
+}
+
+// ValidateSyncRepositoryWithURLRequest creates a validator for SyncRepositoryWithURLRequest.
+func ValidateSyncRepositoryWithURLRequest(newSchema func(*SyncRepositoryWithURLRequest) validating.Schema) httpoption.Validator {
+	return httpoption.FuncValidator(func(value interface{}) error {
+		req := value.(*SyncRepositoryWithURLRequest)
+		return httpoption.Validate(newSchema(req))
+	})
+}
+
+type SyncRepositoryWithURLResponse struct {
+	Err error `json:"-"`
+}
+
+func (r *SyncRepositoryWithURLResponse) Body() interface{} { return r }
+
+// Failed implements endpoint.Failer.
+func (r *SyncRepositoryWithURLResponse) Failed() error { return r.Err }
+
+// MakeEndpointOfSyncRepositoryWithURL creates the endpoint for s.SyncRepositoryWithURL.
+func MakeEndpointOfSyncRepositoryWithURL(s YUM) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(*SyncRepositoryWithURLRequest)
+		err := s.SyncRepositoryWithURL(
+			ctx,
+			req.Repository,
+			req.MirrorURL,
+			req.Wait,
+		)
+		return &SyncRepositoryWithURLResponse{
+			Err: err,
+		}, nil
+	}
+}
+
 type UpdateRepositoryRequest struct {
 	Repository string                `json:"repository"`
 	Properties *RepositoryProperties `json:"properties"`

--- a/pkg/plugins/yum/api/v1/http.go
+++ b/pkg/plugins/yum/api/v1/http.go
@@ -178,6 +178,20 @@ func NewHTTPRouter(svc YUM, codecs httpcodec.Codecs, opts ...httpoption.Option) 
 		),
 	)
 
+	codec = codecs.EncodeDecoder("SyncRepositoryWithURL")
+	validator = options.RequestValidator("SyncRepositoryWithURL")
+	r.Method(
+		"GET", "/repository/sync:url",
+		kithttp.NewServer(
+			MakeEndpointOfSyncRepositoryWithURL(svc),
+			decodeSyncRepositoryWithURLRequest(codec, validator),
+			httpcodec.MakeResponseEncoder(codec, 200),
+			append(kitOptions,
+				kithttp.ServerErrorEncoder(httpcodec.MakeErrorEncoder(codec)),
+			)...,
+		),
+	)
+
 	codec = codecs.EncodeDecoder("UpdateRepository")
 	validator = options.RequestValidator("UpdateRepository")
 	r.Method(
@@ -358,6 +372,22 @@ func decodeRemoveRepositoryPackageByTagRequest(codec httpcodec.Codec, validator 
 func decodeSyncRepositoryRequest(codec httpcodec.Codec, validator httpoption.Validator) kithttp.DecodeRequestFunc {
 	return func(_ context.Context, r *http.Request) (interface{}, error) {
 		var _req SyncRepositoryRequest
+
+		if err := codec.DecodeRequestBody(r, &_req); err != nil {
+			return nil, err
+		}
+
+		if err := validator.Validate(&_req); err != nil {
+			return nil, err
+		}
+
+		return &_req, nil
+	}
+}
+
+func decodeSyncRepositoryWithURLRequest(codec httpcodec.Codec, validator httpoption.Validator) kithttp.DecodeRequestFunc {
+	return func(_ context.Context, r *http.Request) (interface{}, error) {
+		var _req SyncRepositoryWithURLRequest
 
 		if err := codec.DecodeRequestBody(r, &_req); err != nil {
 			return nil, err

--- a/pkg/plugins/yum/api/v1/oas2.go
+++ b/pkg/plugins/yum/api/v1/oas2.go
@@ -168,6 +168,18 @@ paths:
           schema:
             $ref: "#/definitions/SyncRepositoryRequestBody"
       %s
+  /repository/sync:url:
+    get:
+      description: "Sync YUM repository with an upstream repository using a specified URL."
+      operationId: "SyncRepositoryWithURL"
+      tags:
+        - yum
+      parameters:
+        - name: body
+          in: body
+          schema:
+            $ref: "#/definitions/SyncRepositoryWithURLRequestBody"
+      %s
 `
 )
 
@@ -185,6 +197,7 @@ func getResponses(schema oas2.Schema) []oas2.OASResponses {
 		oas2.GetOASResponses(schema, "ListRepositoryLogs", 200, &ListRepositoryLogsResponse{}),
 		oas2.GetOASResponses(schema, "ListRepositoryPackages", 200, &ListRepositoryPackagesResponse{}),
 		oas2.GetOASResponses(schema, "SyncRepository", 200, &SyncRepositoryResponse{}),
+		oas2.GetOASResponses(schema, "SyncRepositoryWithURL", 200, &SyncRepositoryWithURLResponse{}),
 	}
 }
 
@@ -254,6 +267,13 @@ func getDefinitions(schema oas2.Schema) map[string]oas2.Definition {
 		Wait       bool   `json:"wait"`
 	}{}))
 	oas2.AddResponseDefinitions(defs, schema, "SyncRepository", 200, (&SyncRepositoryResponse{}).Body())
+
+	oas2.AddDefinition(defs, "SyncRepositoryWithURLRequestBody", reflect.ValueOf(&struct {
+		Repository string `json:"repository"`
+		MirrorURL  string `json:"mirror_url"`
+		Wait       bool   `json:"wait"`
+	}{}))
+	oas2.AddResponseDefinitions(defs, schema, "SyncRepositoryWithURL", 200, (&SyncRepositoryWithURLResponse{}).Body())
 
 	oas2.AddDefinition(defs, "UpdateRepositoryRequestBody", reflect.ValueOf(&struct {
 		Repository string                `json:"repository"`


### PR DESCRIPTION
Credentials can be configured in repository properies in mirror urls, but these are presisted to the database. This new handler only sets the provided url in memory before performing the sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the Beskar YUM Plugin with new test cases for improved reliability.
  - Implemented repository synchronization feature in the YUM plugin.

- **Bug Fixes**
  - Refined HTTP request handling and authentication processes in integration tests.

- **Refactor**
  - Updated repository configuration logic to support `AuthMirrorURL`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->