### PR TITLE
Fixes issue with insecure storage backends

### DIFF
--- a/internal/pkg/config/sync.go
+++ b/internal/pkg/config/sync.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023-2024, CIQ, Inc. All rights reserved
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "time"
+
+const (
+	DefaultSyncTimeout        = time.Hour
+	DefaultSyncMaxWorkerCount = 10
+)
+
+type SyncConfig struct {
+	Timeout        time.Duration `yaml:"timeout"`
+	MaxWorkerCount int           `yaml:"max_worker_count"`
+}
+
+func (sc SyncConfig) GetTimeout() time.Duration {
+	if sc.Timeout <= 0 {
+		return DefaultSyncTimeout
+	}
+
+	return sc.Timeout
+}
+
+func (sc SyncConfig) GetMaxWorkerCount() int {
+	if sc.MaxWorkerCount <= 0 {
+		return DefaultSyncMaxWorkerCount
+	}
+
+	return sc.MaxWorkerCount
+}

--- a/internal/pkg/pluginsrv/service.go
+++ b/internal/pkg/pluginsrv/service.go
@@ -302,8 +302,12 @@ func getBeskarTransport(caPEM *mtls.CAPEM, beskarMeta *gossip.BeskarMeta) (http.
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 
 	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		// disable insecure connection to beskar
-		return nil, syscall.ECONNREFUSED
+		if addr == beskarAddr {
+			// disable insecure connection to beskar
+			return nil, syscall.ECONNREFUSED
+		}
+
+		return net.Dial(network, addr)
 	}
 
 	transport.DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/internal/pkg/repository/handler.go
+++ b/internal/pkg/repository/handler.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.ciq.dev/beskar/internal/pkg/config"
 	"go.ciq.dev/beskar/internal/pkg/gossip"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -30,6 +31,7 @@ type HandlerParams struct {
 	NameOptions   []name.Option
 	remove        func(string)
 	BeskarMeta    *gossip.BeskarMeta
+	Sync          config.SyncConfig
 }
 
 func (hp HandlerParams) Remove(repository string) {

--- a/internal/plugins/ostree/api.go
+++ b/internal/plugins/ostree/api.go
@@ -72,6 +72,10 @@ func (p *Plugin) SyncRepository(ctx context.Context, repository string, properti
 		return err
 	}
 
+	if properties.Timeout <= 0 {
+		properties.Timeout = p.beskarOSTreeConfig.Sync.Timeout
+	}
+
 	return p.repositoryManager.Get(ctx, repository).SyncRepository(ctx, properties)
 }
 

--- a/internal/plugins/ostree/pkg/config/beskar-ostree.go
+++ b/internal/plugins/ostree/pkg/config/beskar-ostree.go
@@ -29,13 +29,14 @@ const (
 var defaultBeskarOSTreeConfig string
 
 type BeskarOSTreeConfig struct {
-	Version         string        `yaml:"version"`
-	Log             log.Config    `yaml:"log"`
-	Addr            string        `yaml:"addr"`
-	Gossip          gossip.Config `yaml:"gossip"`
-	Profiling       bool          `yaml:"profiling"`
-	DataDir         string        `yaml:"datadir"`
-	ConfigDirectory string        `yaml:"-"`
+	Version         string            `yaml:"version"`
+	Log             log.Config        `yaml:"log"`
+	Addr            string            `yaml:"addr"`
+	Gossip          gossip.Config     `yaml:"gossip"`
+	Profiling       bool              `yaml:"profiling"`
+	DataDir         string            `yaml:"datadir"`
+	ConfigDirectory string            `yaml:"-"`
+	Sync            config.SyncConfig `yaml:"sync"`
 }
 
 type BeskarOSTreeConfigV1 BeskarOSTreeConfig

--- a/internal/plugins/ostree/pkg/config/default/beskar-ostree.yaml
+++ b/internal/plugins/ostree/pkg/config/default/beskar-ostree.yaml
@@ -14,3 +14,7 @@ gossip:
   key: XD1IOhcp0HWFgZJ/HAaARqMKJwfMWtz284Yj7wxmerA=
   peers:
     - 127.0.0.1:5102
+
+sync:
+  timeout: 3600 # 1 hour
+  max_worker_count: 10

--- a/internal/plugins/ostree/pkg/ostreerepository/api.go
+++ b/internal/plugins/ostree/pkg/ostreerepository/api.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/RussellLuo/kun/pkg/werror"
 	"github.com/RussellLuo/kun/pkg/werror/gcode"
@@ -274,7 +273,7 @@ func (h *Handler) SyncRepository(_ context.Context, properties *apiv1.OSTreeRepo
 			h.clearState()
 		}()
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), properties.Timeout)
 		defer cancel()
 
 		err = h.BeginLocalRepoTransaction(ctx, func(ctx context.Context, repo *libostree.Repo) (commit bool, transactionFnErr error) {

--- a/internal/plugins/ostree/pkg/ostreerepository/local.go
+++ b/internal/plugins/ostree/pkg/ostreerepository/local.go
@@ -130,7 +130,7 @@ func (h *Handler) BeginLocalRepoTransaction(ctx context.Context, tFn Transaction
 			ctx,
 			h.repoDir,
 			h.Repository,
-			100,
+			h.Params.Sync.MaxWorkerCount,
 		)
 		repoPusher = repoPusher.WithLogger(h.logger)
 		repoPusher = repoPusher.WithNameOptions(h.Params.NameOptions...)

--- a/internal/plugins/ostree/plugin.go
+++ b/internal/plugins/ostree/plugin.go
@@ -40,8 +40,9 @@ var routerRego []byte
 var routerData []byte
 
 type Plugin struct {
-	ctx    context.Context
-	config pluginsrv.Config
+	ctx                context.Context
+	config             pluginsrv.Config
+	beskarOSTreeConfig *config.BeskarOSTreeConfig
 
 	repositoryManager *repository.Manager[*ostreerepository.Handler]
 	handlerParams     *repository.HandlerParams
@@ -88,7 +89,8 @@ func New(ctx context.Context, beskarOSTreeConfig *config.BeskarOSTreeConfig) (*P
 				},
 			},
 		},
-		handlerParams: params,
+		beskarOSTreeConfig: beskarOSTreeConfig,
+		handlerParams:      params,
 		repositoryManager: repository.NewManager[*ostreerepository.Handler](
 			params,
 			ostreerepository.NewHandler,

--- a/pkg/oras/push.go
+++ b/pkg/oras/push.go
@@ -37,7 +37,7 @@ func Push(pusher Pusher, options ...remote.Option) error {
 		return fmt.Errorf("while getting image index to push: %w", err)
 	} else if err == nil {
 		if err := remote.WriteIndex(ref, imageIndex, options...); err != nil {
-			return fmt.Errorf("while pushing image to %s: %w", ref.Name(), err)
+			return fmt.Errorf("image index list: while pushing image to %s: %w", ref.Name(), err)
 		}
 		return nil
 	}
@@ -47,7 +47,7 @@ func Push(pusher Pusher, options ...remote.Option) error {
 		return fmt.Errorf("while getting image to push: %w", err)
 	} else if err == nil {
 		if err := remote.Write(ref, image, options...); err != nil {
-			return fmt.Errorf("while pushing image to %s: %w", ref.Name(), err)
+			return fmt.Errorf("image index: while pushing image to %s: %w", ref.Name(), err)
 		}
 		return nil
 	}

--- a/pkg/orasostree/repo.go
+++ b/pkg/orasostree/repo.go
@@ -118,7 +118,7 @@ func (p *OSTreeRepositoryPusher) push(path string) error {
 	if p.logger != nil {
 		path = strings.TrimPrefix(path, p.dir)
 		path = strings.TrimPrefix(path, "/")
-		p.logger.Debug("pushing file to beskar", "file", path, "reference", pusher.Reference())
+		p.logger.Debug("pushing file to beskar", "file", path, "reference", pusher.Reference().String())
 	}
 
 	return oras.Push(pusher, p.remoteOpts...)

--- a/pkg/plugins/ostree/api/v1/api.go
+++ b/pkg/plugins/ostree/api/v1/api.go
@@ -6,6 +6,7 @@ package apiv1
 import (
 	"context"
 	"regexp"
+	"time"
 )
 
 const (
@@ -62,6 +63,9 @@ type OSTreeRepositorySyncRequest struct {
 
 	// Depth - The depth of the mirror. Defaults is 0, -1 means infinite.
 	Depth int `json:"depth"`
+
+	// Timeout - The timeout for the sync in seconds. Default is 20 minutes.
+	Timeout time.Duration `json:"timeout"`
 }
 
 // Mirror sync status.


### PR DESCRIPTION

makes sync timeout configurable for ostree plugin
makes sync worker count configurable for ostree plugin
minor logging updates
fixes issue in which beskar plugins were unable to communicate with insecure storage backends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced configuration enhancements for synchronization operations, including timeout settings and worker count adjustments.
	- Improved error messaging for image pushing processes, providing clearer context on failures.

- **Bug Fixes**
	- Adjusted network dialing behavior for specific addresses to correctly handle refused connections.

- **Refactor**
	- Updated various components to utilize dynamic timeout values and worker counts from configuration, replacing hardcoded values.
	- Enhanced logging details for repository pushing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->