### PR TITLE
OSTree HTTPS Changes

### DIFF
--- a/internal/pkg/config/sync.go
+++ b/internal/pkg/config/sync.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	DefaultSyncTimeout        = time.Hour
-	DefaultSyncMaxWorkerCount = 100
+	DefaultSyncMaxWorkerCount = 10
 )
 
 type SyncConfig struct {

--- a/internal/plugins/ostree/pkg/libostree/pull.go
+++ b/internal/plugins/ostree/pkg/libostree/pull.go
@@ -259,3 +259,66 @@ func HTTPHeaders(headers map[string]string) Option {
 		)
 	}
 }
+
+// TLSPermissive sets the tls-permissive option to true in the pull options.
+// A boolean value, defaults to false. By default, server TLS certificates will be checked against the system certificate
+// store. If this variable is set, any certificate will be accepted.
+func TLSPermissive() Option {
+	return func(builder *C.GVariantBuilder, deferFree deferredFreeFn) {
+		key := C.CString("tls-permissive")
+		deferFree(unsafe.Pointer(key))
+		gVariantBuilderAddVariant(
+			builder,
+			key,
+			C.g_variant_new_variant(C.g_variant_new_boolean(C.gboolean(1))),
+		)
+	}
+}
+
+// TLSClientCertPath sets the tls-client-cert-path option to the given value in the pull options.
+// Path to file for client-side certificate, to present when making requests to this repository.
+func TLSClientCertPath(path string) Option {
+	return func(builder *C.GVariantBuilder, deferFree deferredFreeFn) {
+		key := C.CString("tls-client-cert-path")
+		deferFree(unsafe.Pointer(key))
+		value := C.CString(path)
+		deferFree(unsafe.Pointer(value))
+		gVariantBuilderAddVariant(
+			builder,
+			key,
+			C.g_variant_new_variant(C.g_variant_new_string(value)),
+		)
+	}
+}
+
+// TLSClientKeyPath sets the tls-client-key-path option to the given value in the pull options.
+// Path to file containing client-side certificate key, to present when making requests to this repository.
+func TLSClientKeyPath(path string) Option {
+	return func(builder *C.GVariantBuilder, deferFree deferredFreeFn) {
+		key := C.CString("tls-client-key-path")
+		deferFree(unsafe.Pointer(key))
+		value := C.CString(path)
+		deferFree(unsafe.Pointer(value))
+		gVariantBuilderAddVariant(
+			builder,
+			key,
+			C.g_variant_new_variant(C.g_variant_new_string(value)),
+		)
+	}
+}
+
+// TLSCAPath sets the tls-ca-path option to the given value in the pull options.
+// Path to file containing trusted anchors instead of the system CA database.
+func TLSCAPath(path string) Option {
+	return func(builder *C.GVariantBuilder, deferFree deferredFreeFn) {
+		key := C.CString("tls-ca-path")
+		deferFree(unsafe.Pointer(key))
+		value := C.CString(path)
+		deferFree(unsafe.Pointer(value))
+		gVariantBuilderAddVariant(
+			builder,
+			key,
+			C.g_variant_new_variant(C.g_variant_new_string(value)),
+		)
+	}
+}

--- a/internal/plugins/ostree/pkg/ostreerepository/handler.go
+++ b/internal/plugins/ostree/pkg/ostreerepository/handler.go
@@ -133,7 +133,7 @@ func (h *Handler) Start(ctx context.Context) {
 // pullConfig pulls the config file from beskar.
 func (h *Handler) pullFile(ctx context.Context, filename string) error {
 	// TODO: Replace with appropriate puller mechanism
-	url := "http://" + h.Params.GetBeskarRegistryHostPort() + path.Join("/", h.Repository, "repo", filename)
+	url := "https://" + h.Params.GetBeskarRegistryHostPort() + path.Join("/", h.Repository, "repo", filename)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err

--- a/internal/plugins/ostree/pkg/ostreerepository/local.go
+++ b/internal/plugins/ostree/pkg/ostreerepository/local.go
@@ -94,7 +94,7 @@ func (h *Handler) BeginLocalRepoTransaction(ctx context.Context, tFn Transaction
 	}
 
 	// Add beskar as a remote so that we can pull from it
-	beskarServiceURL := "http://" + h.Params.GetBeskarRegistryHostPort() + path.Join("/", h.Repository, "repo")
+	beskarServiceURL := "https://" + h.Params.GetBeskarRegistryHostPort() + path.Join("/", h.Repository, "repo")
 	if err := repo.AddRemote(beskarRemoteName, beskarServiceURL, libostree.NoGPGVerify()); err != nil {
 		return ctl.Errf("adding remote to ostree repository %s: %s", beskarRemoteName, err)
 	}
@@ -104,11 +104,7 @@ func (h *Handler) BeginLocalRepoTransaction(ctx context.Context, tFn Transaction
 		if err := repo.Pull(
 			ctx,
 			beskarRemoteName,
-			h.standardPullOptions(
-				libostree.HTTPHeaders(map[string]string{
-					"Connection": "close",
-				}),
-			)...,
+			h.standardPullOptions()...,
 		); err != nil {
 			return ctl.Errf("pulling ostree repository from %s: %s", beskarRemoteName, err)
 		}


### PR DESCRIPTION
adds tls related options to libostree bindings
hardcodes https for ostree plugin - a better option can be implemented once it's needed
reduces default worker count to a more reasonable value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new TLS configuration options for enhanced security during data transfers.

- **Enhancements**
  - Improved security by switching URL protocols from HTTP to HTTPS in various operations to ensure secure communication.

- **Configuration Changes**
  - Adjusted the default maximum worker count for synchronization tasks from 100 to 10 to optimize resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->