### PR TITLE
Update registry logger output and format

### DIFF
--- a/internal/pkg/beskar/registry.go
+++ b/internal/pkg/beskar/registry.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"reflect"
 	"strconv"
 	"syscall"
@@ -90,8 +91,12 @@ func New(beskarConfig *config.BeskarConfig) (context.Context, *Registry, error) 
 	ctx, waitFunc := sighandler.New(beskarRegistry.errCh, syscall.SIGINT)
 	beskarRegistry.wait = waitFunc
 
+	logger := logrus.StandardLogger()
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	logger.SetOutput(os.Stdout)
+
 	beskarRegistry.router = mux.NewRouter()
-	beskarRegistry.logger = logrus.StandardLogger().WithField("version", version.Semver).WithField("service", "beskar")
+	beskarRegistry.logger = logger.WithField("version", version.Semver).WithField("service", "beskar")
 
 	// for probes
 	beskarRegistry.router.Handle("/", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))


### PR DESCRIPTION
This change updates the registry's logger to output logs in JSON on stdout. This makes it easier for logging/monitoring tools to ingest and correctly categorize beskar logs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced logging with JSON formatting for better readability and integration with logging systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->