### PR TITLE
chore(ci): bump GitHub Actions off Node 20 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     name: lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run linters
         run: ./scripts/mage lint:all
 
@@ -18,10 +18,10 @@ jobs:
     name: tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run unit tests
         run: ./scripts/mage test:unit
       - name: Run integration tests
@@ -31,9 +31,9 @@ jobs:
     name: build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Build binaries
         run: ./scripts/mage build:all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     name: lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run linters
         run: ./scripts/mage lint:all
 
@@ -20,10 +20,10 @@ jobs:
     name: tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run unit tests
         run: ./scripts/mage test:unit
       - name: Run integration tests
@@ -34,10 +34,10 @@ jobs:
     needs: [lint, tests]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Release beskar image
         run: ./scripts/mage ci:image ghcr.io/ctrliq/beskar:${{ github.ref_name }} "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
       - name: Release beskar helm chart
@@ -48,10 +48,10 @@ jobs:
     needs: [lint, tests]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Release beskar-yum image
         run: ./scripts/mage ci:image ghcr.io/ctrliq/beskar-yum:${{ github.ref_name }} "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
       - name: Release beskar-yum helm chart
@@ -62,10 +62,10 @@ jobs:
     needs: [lint, tests]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Release beskar-static image
         run: ./scripts/mage ci:image ghcr.io/ctrliq/beskar-static:${{ github.ref_name }} "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
       - name: Release beskar-static helm chart
@@ -76,12 +76,12 @@ jobs:
     needs: [lint, tests]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.21'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Release beskar-ostree image
         run: ./scripts/mage ci:image ghcr.io/ctrliq/beskar-ostree:${{ github.ref_name }} "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
       - name: Release beskar-ostree helm chart
@@ -92,10 +92,10 @@ jobs:
     needs: [lint, tests]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Release beskar-mirror image
         run: ./scripts/mage ci:image ghcr.io/ctrliq/beskar-mirror:${{ github.ref_name }} "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
       - name: Release beskar-mirror helm chart


### PR DESCRIPTION
## Summary

Node 20 reached EOL on 2026-04-30. This PR bumps GitHub Actions to current stable releases, pinned by full commit SHA with the target tag in a trailing comment.


## Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v3` | `v6.0.2` |
| `actions/setup-go` | `v3` | `v6.4.0` |

Files touched: **2** workflow file(s), **20** line change(s).

## Test plan

- [ ] Existing CI runs on this PR and stays green.
- [ ] If this repo's workflows aren't PR-triggered, dispatch them manually after merge or via `workflow_dispatch`.

---

Part of an org-wide bulk update across ~135 ctrliq repos to escape Node 20 EOL.
