### PR TITLE
Pin GitHub Actions to SHAs [SRE-1802]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     name: lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Run linters
         run: ./scripts/mage lint:all
 
@@ -18,10 +18,10 @@ jobs:
     name: tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Run unit tests
         run: ./scripts/mage test:unit
       - name: Run integration tests
@@ -31,9 +31,9 @@ jobs:
     name: build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Build binaries
         run: ./scripts/mage build:all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     name: lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Run linters
         run: ./scripts/mage lint:all
 
@@ -20,10 +20,10 @@ jobs:
     name: tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Run unit tests
         run: ./scripts/mage test:unit
       - name: Run integration tests
@@ -34,10 +34,10 @@ jobs:
     needs: [lint, tests]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Release beskar image
         run: ./scripts/mage ci:image ghcr.io/ctrliq/beskar:${{ github.ref_name }} "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
       - name: Release beskar helm chart
@@ -48,10 +48,10 @@ jobs:
     needs: [lint, tests]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Release beskar-yum image
         run: ./scripts/mage ci:image ghcr.io/ctrliq/beskar-yum:${{ github.ref_name }} "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
       - name: Release beskar-yum helm chart
@@ -62,10 +62,10 @@ jobs:
     needs: [lint, tests]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Release beskar-static image
         run: ./scripts/mage ci:image ghcr.io/ctrliq/beskar-static:${{ github.ref_name }} "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
       - name: Release beskar-static helm chart
@@ -76,12 +76,12 @@ jobs:
     needs: [lint, tests]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - uses: actions/checkout@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Release beskar-ostree image
         run: ./scripts/mage ci:image ghcr.io/ctrliq/beskar-ostree:${{ github.ref_name }} "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
       - name: Release beskar-ostree helm chart
@@ -92,10 +92,10 @@ jobs:
     needs: [lint, tests]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: '1.21'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Release beskar-mirror image
         run: ./scripts/mage ci:image ghcr.io/ctrliq/beskar-mirror:${{ github.ref_name }} "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}"
       - name: Release beskar-mirror helm chart


### PR DESCRIPTION
## Summary
Pin GitHub Actions references in this repo to immutable commit SHAs (with the original tag/branch preserved in a trailing comment). Part of [SRE-1802](https://ciqinc.atlassian.net/browse/SRE-1802) — org-wide supply-chain hardening.

## Scope
This PR pins:
- Internal `ctrliq/*` reusable workflow and action references
- External actions **not** handled by clo-ciq's parallel Node 20 effort

_No actions in this repo were claimed by clo-ciq's effort — this PR pins everything._

## Files touched

- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

## Test plan
- [ ] Workflow runs succeed on this branch (or on next trigger after merge)
- [ ] Once this and any companion clo-ciq PR merge, this repo has zero unpinned external/internal refs and `sha_pinning_required` can be enabled on it

[SRE-1802]: https://ciqinc.atlassian.net/browse/SRE-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ